### PR TITLE
feat: Show module updates in KSU Managers

### DIFF
--- a/.github/workflows/sync-on-release.yml
+++ b/.github/workflows/sync-on-release.yml
@@ -1,0 +1,74 @@
+name: Sync module.prop and update.json on release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: main
+
+      - name: Get release info from event
+        id: release
+        run: |
+          set +x
+          if [ -n "${{ github.event.release.tag_name }}" ]; then
+            TAG_NAME="${{ github.event.release.tag_name }}"
+            CHANGELOG_URL="${{ github.event.release.html_url }}"
+            ZIP_URL=$(jq -r '.release.assets[] | select(.name | endswith(".zip")) | .browser_download_url' $GITHUB_EVENT_PATH 2>/dev/null | head -n1)
+          else
+            echo "No release event; run manually or trigger by publishing a release"
+            exit 1
+          fi
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "changelog=$CHANGELOG_URL" >> $GITHUB_OUTPUT
+          echo "zipUrl=${ZIP_URL:-}" >> $GITHUB_OUTPUT
+          echo "Release: $TAG_NAME"
+          echo "zipUrl=$ZIP_URL"
+          echo "changelog=$CHANGELOG_URL"
+
+      - name: Bump version and versionCode in module.prop
+        id: prop
+        run: |
+          set +x
+          CURRENT_CODE=$(grep '^versionCode=' module.prop | cut -d= -f2)
+          NEW_CODE=$((${CURRENT_CODE:-0} + 1))
+          TAG_NAME="${{ steps.release.outputs.tag_name }}"
+          sed -i "s/^version=.*/version=${TAG_NAME}/" module.prop
+          sed -i "s/^versionCode=.*/versionCode=${NEW_CODE}/" module.prop
+          echo "version=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "versionCode=$NEW_CODE" >> $GITHUB_OUTPUT
+          echo "Updated module.prop: version=$TAG_NAME versionCode=$NEW_CODE (was $CURRENT_CODE)"
+
+      - name: Write update.json
+        run: |
+          set +x
+          jq -n \
+            --arg version "${{ steps.prop.outputs.version }}" \
+            --argjson versionCode ${{ steps.prop.outputs.versionCode }} \
+            --arg zipUrl "${{ steps.release.outputs.zipUrl }}" \
+            --arg changelog "${{ steps.release.outputs.changelog }}" \
+            '{version: $version, versionCode: $versionCode, zipUrl: $zipUrl, changelog: $changelog}' > update.json
+          echo "Written update.json:"
+          cat update.json
+
+      - name: Commit and push
+        run: |
+          set +x
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add module.prop update.json
+          if git diff --staged --quiet; then
+            echo "No changes"
+          else
+            git commit -m "chore(ci): sync module.prop and update.json for release ${{ steps.release.outputs.tag_name }}"
+            git push
+          fi

--- a/module.prop
+++ b/module.prop
@@ -4,3 +4,4 @@ version=v0.0.36
 versionCode=1
 author=rrr333nnn333, KOWX712, sidex15 & simonpunk@gitlab.com
 description=[Module Status: ❓, SuSFS Patches: ❓] A SuSFS/KernelSU module for SuSFS patched kernels
+updateJson=https://raw.githubusercontent.com/rrr333nnn333/BRENE/main/update.json

--- a/update.json
+++ b/update.json
@@ -1,0 +1,6 @@
+{
+  "version": "v0.0.36",
+  "versionCode": 1,
+  "zipUrl": "https://github.com/rrr333nnn333/BRENE/releases/download/v0.0.36/BRENE-v0.0.36.zip",
+  "changelog": "https://github.com/rrr333nnn333/BRENE/releases/tag/v0.0.36"
+}


### PR DESCRIPTION
## Summary

This PR adds KernelSU module update notification support so users see an "Update" button in KernelSU Manager when a new release is available. It follows the same pattern as [KernelSU's updateJson support](https://kernelsu.org/guide/module.html).

## What's included

- **update.json**: Added a new JSON file with `version`, `versionCode`, `zipUrl`, and `changelog`. The manager compares `versionCode` with the installed module and shows "Update" only when the remote `versionCode` is **greater** than the installed one and `zipUrl` is non-empty.
- **module.prop**: Edited to add a new `updateJson` pointing at this repo's raw `update.json` URL so the manager can check for updates.
- **GitHub Action** (`.github/workflows/sync-on-release.yml`): Runs when a **release is published**. It:
  - Reads the current `versionCode` from `module.prop`, increments it, and sets `version` to the release tag (e.g. `v0.0.37`).
  - Sets `update.json` from the release: `version` = tag, `versionCode` = incremented value, `zipUrl` = first `.zip` asset in the new release, `changelog` = new release page URL.
  - Commits and pushes both files to `main`.
No manual editing of `module.prop` or `update.json` is needed for version/versionCode or zip/changelog.
---
## Instructions for you (maintainer)
### Release flow (after merging)
1. You build the module zip.
2. Create and **publish** a new [GitHub Release](https://github.com/rrr333nnn333/BRENE/releases/new) (e.g. tag `v0.0.37`) and **upload the zip** as an asset.
3. The workflow runs automatically, bumps `versionCode` in `module.prop`, sets `version` to the release tag, updates `update.json` with the new zip and changelog URL, and pushes both to `main`.
You do **not** need to edit `module.prop` or `update.json` yourself; the workflow keeps them in sync with each release.
### Why `versionCode` matters
KernelSU Manager only shows "Update" when the **remote** `versionCode` is **greater** than the **installed** one. The workflow increments `versionCode` on every release so each new release is detected as an update.
### One-time after merging
- `updateJson` in `module.prop` is set to:  
  `https://raw.githubusercontent.com/rrr333nnn333/BRENE/main/update.json`  
  No change needed unless you move or rename the repo.