### PR TITLE
fix: update.json changelog link can't load

### DIFF
--- a/update.json
+++ b/update.json
@@ -2,5 +2,5 @@
 	"version": "v0.0.50",
 	"versionCode": 50,
 	"zipUrl": "https://github.com/rrr333nnn333/BRENE/releases/latest/download/BRENE.zip",
-	"changelog": "https://raw.githubusercontent.com/rrr333nnn333/BRENE/refs/heads/main/CHANGELOG.md"
+	"changelog": "https://raw.githubusercontent.com/rrr333nnn333/BRENE/refs/heads/main/%E2%80%8ECHANGELOG.md"
 }


### PR DESCRIPTION
# Description 
- Just like the title, the old link returned 404 not found error.