### PR TITLE
fix: keep MIUI folder on MIUI/HyperOS to avoid recording failures

### DIFF
--- a/boot-completed.sh
+++ b/boot-completed.sh
@@ -109,8 +109,12 @@ if [[ "${config_paths_hiding__non_standard_sdcard}" == "1" ]]; then
 			echo "####################"
 		} >> "${PERSISTENT_DIR}/logs.txt"
 	fi
-
-	standard_paths="Alarms Android Audiobooks DCIM Documents Download Movies Music Notifications Pictures Podcasts Recordings Ringtones"
+	
+    if [[ -n "$(resetprop ro.miui.ui.version.name)" ]]; then
+        standard_paths="Alarms Android Audiobooks DCIM Documents Download MIUI Movies Music Notifications Pictures Podcasts Recordings Ringtones"
+    else
+        standard_paths="Alarms Android Audiobooks DCIM Documents Download Movies Music Notifications Pictures Podcasts Recordings Ringtones"
+    fi
 	for i in /sdcard/*; do
 		pass=0
 		for x in ${standard_paths}; do

--- a/boot-completed.sh
+++ b/boot-completed.sh
@@ -109,12 +109,13 @@ if [[ "${config_paths_hiding__non_standard_sdcard}" == "1" ]]; then
 			echo "####################"
 		} >> "${PERSISTENT_DIR}/logs.txt"
 	fi
-	
-    if [[ -n "$(resetprop ro.miui.ui.version.name)" ]]; then
-        standard_paths="Alarms Android Audiobooks DCIM Documents Download MIUI Movies Music Notifications Pictures Podcasts Recordings Ringtones"
-    else
-        standard_paths="Alarms Android Audiobooks DCIM Documents Download Movies Music Notifications Pictures Podcasts Recordings Ringtones"
-    fi
+
+	if [[ -z "$(resetprop ro.miui.ui.version.name)" ]]; then
+		standard_paths="Alarms Android Audiobooks DCIM Documents Download Movies Music Notifications Pictures Podcasts Recordings Ringtones"
+	else
+		standard_paths="Alarms Android Audiobooks DCIM Documents Download Movies Music Notifications Pictures Podcasts Recordings Ringtones MIUI"
+	fi
+
 	for i in /sdcard/*; do
 		pass=0
 		for x in ${standard_paths}; do


### PR DESCRIPTION
On Xiaomi/Redmi devices running MIUI or HyperOS, the system recorder, call recording, and other audio recording functions rely on the /sdcard/MIUI folder.

When the 'Non-standard /sdcard' hiding feature is enabled, the script previously treated all folders not in the fixed standard_paths as suspicious. Since 'MIUI' was not included by default, it was hidden, causing recording-related apps to malfunction.

This fix adds a runtime detection based on property `ro.miui.ui.version.name`. If this property is non-empty (indicating MIUI/HyperOS family), the MIUI folder is added to the list of standard_paths and thus excluded from hiding. On other systems, the MIUI folder remains hidden as it is considered non-standard.

Fixes the issue where recordings fail after enabling non-standard /sdcard hiding on MIUI/HyperOS devices.