### PR TITLE
Add Auto/Manual /data/adb modules path hiding

### DIFF
--- a/boot-completed.sh
+++ b/boot-completed.sh
@@ -222,6 +222,49 @@ if [[ "${config_paths_hiding__sdcard_android_data_media_obb}" == "1" ]]; then
 	# done
 fi
 
+# /data/adb and /data/adb/modules (Auto)
+# Auto Hide All Modules paths: hides /data/adb itself and every path under /data/adb/modules automatically
+# This is mutually exclusive with Manual Modules Hide, Auto is skipped if Manual is enabled
+if [[ "${config_paths_hiding__data_adb_auto}" == "1" && "${config_paths_hiding__data_adb_manual}" != "1" ]]; then
+	if [[ "${config_brene_logs}" == "1" ]]; then
+		{
+			echo ""
+			echo "############################"
+			echo "/data/adb (Auto)"
+			echo "############################"
+		} >> "${PERSISTENT_DIR}/logs.txt"
+	fi
+
+	brene_sus_path_loop "/data/adb"
+
+	for i in /data/adb/modules/*; do
+		brene_sus_path_loop "${i}"
+	done
+fi
+
+# /data/adb/modules (Manual)
+# Manual Modules Hide: hides only the modules selected by the user in "manual_hidden_modules.txt"
+# This is mutually exclusive with Auto Hide All Modules paths, Manual is skipped if Auto is enabled
+if [[ "${config_paths_hiding__data_adb_manual}" == "1" && "${config_paths_hiding__data_adb_auto}" != "1" ]]; then
+	if [[ "${config_brene_logs}" == "1" ]]; then
+		{
+			echo ""
+			echo "############################"
+			echo "/data/adb/modules (Manual)"
+			echo "############################"
+		} >> "${PERSISTENT_DIR}/logs.txt"
+	fi
+
+	if [[ -e "${PERSISTENT_DIR}/manual_hidden_modules.txt" ]]; then
+		while IFS= read -r i; do
+			# Skip empty lines or comments
+			[[ -z "${i// /}" || "${i// /}" == "#"* ]] && continue
+
+			[[ -e "/data/adb/modules/${i}" ]] && brene_sus_path_loop "/data/adb/modules/${i}"
+		done < "${PERSISTENT_DIR}/manual_hidden_modules.txt"
+	fi
+fi
+
 ## For paths that are read-only all the time, add them via 'add_sus_path' ##
 if [[ "${config_brene_logs}" == "1" ]]; then
 	{

--- a/boot-completed.sh
+++ b/boot-completed.sh
@@ -239,6 +239,16 @@ if [[ "${config_paths_hiding__data_adb_auto}" == "1" && "${config_paths_hiding__
 
 	for i in /data/adb/modules/*; do
 		brene_sus_path_loop "${i}"
+
+		if [[ -e "${i}/system" ]]; then
+			for x in $(find "${i}/system" -type f); do
+				brene_sus_map "${x}"
+			done
+		fi
+
+		for x in $(find "${i}" -name "*.so"); do
+			brene_sus_map "${x}"
+		done
 	done
 fi
 
@@ -260,7 +270,19 @@ if [[ "${config_paths_hiding__data_adb_manual}" == "1" && "${config_paths_hiding
 			# Skip empty lines or comments
 			[[ -z "${i// /}" || "${i// /}" == "#"* ]] && continue
 
-			[[ -e "/data/adb/modules/${i}" ]] && brene_sus_path_loop "/data/adb/modules/${i}"
+			if [[ -e "/data/adb/modules/${i}" ]]; then
+				brene_sus_path_loop "/data/adb/modules/${i}"
+
+				if [[ -e "/data/adb/modules/${i}/system" ]]; then
+					for x in $(find "/data/adb/modules/${i}/system" -type f); do
+						brene_sus_map "${x}"
+					done
+				fi
+
+				for x in $(find "/data/adb/modules/${i}" -name "*.so"); do
+					brene_sus_map "${x}"
+				done
+			fi
 		done < "${PERSISTENT_DIR}/manual_hidden_modules.txt"
 	fi
 fi

--- a/config.sh
+++ b/config.sh
@@ -4,6 +4,8 @@ config_paths_hiding__non_standard_sdcard=1
 config_paths_hiding__non_standard_sdcard_android=1
 config_paths_hiding__data_local_tmp=1
 config_paths_hiding__sdcard_android_data_media_obb=1
+config_paths_hiding__data_adb_auto=0
+config_paths_hiding__data_adb_manual=0
 
 config_selinux=1
 config_su_compat=1

--- a/customize.sh
+++ b/customize.sh
@@ -60,6 +60,7 @@ custom_sus_map.txt
 custom_sus_mount.txt
 custom_sus_path.txt
 custom_sus_path_loop.txt
+manual_hidden_modules.txt
 "
 for file in ${files}; do
 	if [[ ! -f "${PERSISTENT_DIR}/${file}" ]]; then

--- a/webroot/index.html
+++ b/webroot/index.html
@@ -300,6 +300,35 @@
 						<md-switch icons id="paths_hiding__sdcard_android_data_media_obb"></md-switch>
 						<md-ripple></md-ripple>
 					</div>
+
+					<div class="card-row">
+						<div class="card-row__body">
+							<span class="card-row__title">Auto Hide All Modules paths</span>
+							<span class="card-row__sub">Automatically hides /data/adb and every path under /data/adb/modules</span>
+							<span class="card-row__sub card-row__tag--danger">WARNING:</span>
+							<span class="card-row__sub card-row__tag--danger">- Cannot be used together with Manual Modules Hide, enabling this disables it</span>
+						</div>
+						<md-switch icons id="paths_hiding__data_adb_auto"></md-switch>
+						<md-ripple></md-ripple>
+					</div>
+
+					<div class="card-row">
+						<div class="card-row__body">
+							<span class="card-row__title">Manual Modules Hide</span>
+							<span class="card-row__sub">Hide only the modules you select below, path by path, instead of all of /data/adb/modules</span>
+							<span class="card-row__sub card-row__tag--danger">WARNING:</span>
+							<span class="card-row__sub card-row__tag--danger">- Cannot be used together with Auto Hide All Modules paths, enabling this disables it</span>
+						</div>
+						<md-switch icons id="paths_hiding__data_adb_manual"></md-switch>
+						<md-ripple></md-ripple>
+					</div>
+
+					<div class="card-row" id="manual_modules_hide_list">
+						<div class="card-row__body">
+							<span class="card-row__title">Modules</span>
+							<span class="card-row__sub">Enable Manual Modules Hide above, then pick which modules to hide</span>
+						</div>
+					</div>
 				</div>
 
 				<p class="section-label">Mounts Hiding</p>

--- a/webroot/index.html
+++ b/webroot/index.html
@@ -323,12 +323,13 @@
 						<md-ripple></md-ripple>
 					</div>
 
-					<div class="card-row" id="manual_modules_hide_list">
+					<div class="card-row">
 						<div class="card-row__body">
 							<span class="card-row__title">Modules</span>
 							<span class="card-row__sub">Enable Manual Modules Hide above, then pick which modules to hide</span>
 						</div>
 					</div>
+					<div id="manual_modules_hide_list"></div>
 				</div>
 
 				<p class="section-label">Mounts Hiding</p>

--- a/webroot/script.js
+++ b/webroot/script.js
@@ -329,16 +329,16 @@ UNIQUE_EOF
 
 		listContainer.innerHTML = ''
 
-		const title = document.createElement('div')
-		title.className = 'card-row__body'
-		title.innerHTML = '<span class="card-row__title">Modules</span>'
-		listContainer.appendChild(title)
-
 		if (modules.length === 0) {
-			const empty = document.createElement('span')
-			empty.className = 'card-row__sub'
-			empty.innerText = 'No modules found'
-			title.appendChild(empty)
+			const row = document.createElement('div')
+			row.className = 'card-row'
+
+			const body = document.createElement('div')
+			body.className = 'card-row__body'
+			body.innerHTML = '<span class="card-row__sub">No modules found</span>'
+
+			row.appendChild(body)
+			listContainer.appendChild(row)
 			return
 		}
 

--- a/webroot/script.js
+++ b/webroot/script.js
@@ -59,6 +59,8 @@ const configs = [
 	{ id: 'paths_hiding__non_standard_sdcard_android' },
 	{ id: 'paths_hiding__data_local_tmp' },
 	{ id: 'paths_hiding__sdcard_android_data_media_obb' },
+	{ id: 'paths_hiding__data_adb_auto' },
+	{ id: 'paths_hiding__data_adb_manual' },
 ]
 
 // Open URLs
@@ -287,6 +289,117 @@ exec(`cat ${PERSISTENT_DIR}/config.sh`).then((result) => {
 		})
 	})
 })
+
+// Auto/Manual Modules Hide mutual exclusivity and manual per-module list
+;(async () => {
+	const autoSwitch = document.getElementById('paths_hiding__data_adb_auto')
+	const manualSwitch = document.getElementById('paths_hiding__data_adb_manual')
+	const listContainer = document.getElementById('manual_modules_hide_list')
+
+	// Helper function to read the manual hidden modules list
+	function readManualHiddenModules() {
+		return exec(`cat ${PERSISTENT_DIR}/manual_hidden_modules.txt`).then((result) => {
+			if (result.errno !== 0) return []
+			return result.stdout
+				.split('\n')
+				.map((line) => line.trim())
+				.filter((line) => line !== '' && !line.startsWith('#'))
+		})
+	}
+
+	// Helper function to write the manual hidden modules list
+	function writeManualHiddenModules(ids) {
+		const content = ids.join('\n')
+		return exec(`
+cat <<'UNIQUE_EOF' > ${PERSISTENT_DIR}/manual_hidden_modules.txt
+${content}
+UNIQUE_EOF
+		`).then((result) => {
+			if (result.errno !== 0) toast('Failed to update manual hidden modules')
+		})
+	}
+
+	// Render the module list with a checkbox per module
+	async function renderManualModulesList(manualEnabled) {
+		const moduleResult = await exec('ksud module list')
+		if (moduleResult.errno !== 0) return
+
+		const modules = JSON.parse(moduleResult.stdout)
+		const hiddenIds = await readManualHiddenModules()
+
+		listContainer.innerHTML = ''
+
+		const title = document.createElement('div')
+		title.className = 'card-row__body'
+		title.innerHTML = '<span class="card-row__title">Modules</span>'
+		listContainer.appendChild(title)
+
+		if (modules.length === 0) {
+			const empty = document.createElement('span')
+			empty.className = 'card-row__sub'
+			empty.innerText = 'No modules found'
+			title.appendChild(empty)
+			return
+		}
+
+		modules.forEach((mod) => {
+			const row = document.createElement('div')
+			row.className = 'card-row'
+
+			const body = document.createElement('div')
+			body.className = 'card-row__body'
+			body.innerHTML = `<span class="card-row__title">${mod.name || mod.id}</span><span class="card-row__sub">${mod.id}</span>`
+
+			const toggle = document.createElement('md-switch')
+			toggle.setAttribute('icons', '')
+			toggle.selected = hiddenIds.includes(mod.id)
+			toggle.disabled = manualEnabled !== true
+
+			toggle.addEventListener('change', async () => {
+				const currentIds = await readManualHiddenModules()
+				const newIds = toggle.selected ? Array.from(new Set([...currentIds, mod.id])) : currentIds.filter((id) => id !== mod.id)
+				writeManualHiddenModules(newIds)
+			})
+
+			row.appendChild(body)
+			row.appendChild(toggle)
+			listContainer.appendChild(row)
+		})
+	}
+
+	function setManualModulesListEnabled(enabled) {
+		listContainer.querySelectorAll('md-switch').forEach((toggle) => {
+			toggle.disabled = !enabled
+		})
+	}
+
+	autoSwitch.addEventListener('change', () => {
+		if (autoSwitch.selected && manualSwitch.selected) {
+			manualSwitch.selected = false
+			manualSwitch.dispatchEvent(new Event('change'))
+		}
+	})
+
+	manualSwitch.addEventListener('change', () => {
+		if (manualSwitch.selected && autoSwitch.selected) {
+			autoSwitch.selected = false
+			autoSwitch.dispatchEvent(new Event('change'))
+		}
+		setManualModulesListEnabled(manualSwitch.selected)
+	})
+
+	// Read config.sh directly so the initial state does not depend on the other config-loading block's timing
+	const configResult = await exec(`cat ${PERSISTENT_DIR}/config.sh`)
+	let manualEnabled = false
+	if (configResult.errno === 0) {
+		const manualLine = configResult.stdout.split('\n').find((line) => line.trim().startsWith('config_paths_hiding__data_adb_manual='))
+		const manualValue = manualLine ? manualLine.split('=')[1].trim() : '0'
+		manualEnabled = parseInt(manualValue) === 1
+	}
+
+	await renderManualModulesList(manualEnabled)
+	setManualModulesListEnabled(manualEnabled)
+})()
 
 // KSU Modules toggles
 ;(async () => {


### PR DESCRIPTION
## What this adds

Two new mutually exclusive options for hiding `/data/adb` and `/data/adb/modules`:

- **Auto Hide All Modules paths** — automatically hides `/data/adb` and everything
  under `/data/adb/modules` via `brene_sus_path_loop`.
- **Manual Modules Hide** — lists every installed module in the webui with its own
  switch, hiding only the ones you select (stored in `manual_hidden_modules.txt`).

Enabling one automatically disables the other, both in the webui and as a safety
check in `boot-completed.sh`, so they can never run at the same time.

## Changes

- `config.sh`: add `config_paths_hiding__data_adb_auto` and
  `config_paths_hiding__data_adb_manual` (default `0`)
- `boot-completed.sh`: add the Auto and Manual hiding blocks after the
  `/sdcard/Android/[data|media|obb]` block
- `customize.sh`: auto-create `manual_hidden_modules.txt` on install
- `webroot/index.html`: add the Auto/Manual switches and the module list section
  under Paths Hiding
- `webroot/script.js`: render the module list, persist manual selections per
  module, enforce mutual exclusivity between Auto and Manual

## Screenshot

Screenshot attached showing the new "Auto Hide All Modules paths" / "Manual
Modules Hide" switches and the per-module list underneath.
<img width="1200" height="2000" alt="Screenshot_20260726-171642_ReSukiSU" src="https://github.com/user-attachments/assets/4bae7dd8-d802-4733-835d-645b6093378e" />
